### PR TITLE
Dentro de poco por pronto y nuevo texto

### DIFF
--- a/Spanish/main/Calendar.apk/res/values-es/strings.xml
+++ b/Spanish/main/Calendar.apk/res/values-es/strings.xml
@@ -71,10 +71,10 @@
      <string name="birthday_event_description_yesterday">Ayer fue</string>
      <string name="birthday_metric" />
      <string name="birthday_notification_age_term" />
-     <string name="birthday_notification_text_days_later">%1$s days until %4$s (%5$s)</string>
+     <string name="birthday_notification_text_days_later">%1$s días para el %4$s (%5$s)</string>
      <string name="birthday_notification_text_three_days_later">3 días para el %3$s (%4$s)</string>
      <string name="birthday_notification_text_today">No olvides felicitarle</string>
-     <string name="birthday_notification_title_days_later">Dentro de poco será el %2$s de %1$s</string>
+     <string name="birthday_notification_title_days_later">Pronto será el %2$s de %1$s</string>
      <string name="birthday_notification_title_three_days_later">El %2$s de %1$s se acerca</string>
      <string name="birthday_notification_title_today">%3$s de %1$s</string>
      <string name="birthday_notification_type_term_lunar" />


### PR DESCRIPTION
Con la frase "Dentro de poco será el cumpleaños de X" no cabía toda en la pantalla y no sabías de quien iba a ser el cumpleaños si no la pulsabas, acortando la frase se puede ver en la propia notificación y descartarla sin entrar en ella.